### PR TITLE
Fix sparse vector 'clear' resetting noData below 1

### DIFF
--- a/src/sparse-vector.h
+++ b/src/sparse-vector.h
@@ -132,6 +132,6 @@ public:
 	{
 		index.clear();
 		data.clear();
-		noData.clear();
+		noData.resize(1);
 	}
 };


### PR DESCRIPTION
This little PR fixes clearing a sparse vector which breaks it (`noData` is emptied, breaking next `set` operation). This causes the second run of a Serum colored game to crash when using VPX.