### PR TITLE
A black frame in the project should still be found and displayed, but..

### DIFF
--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -4530,6 +4530,7 @@ static uint32_t Serum_ColorizeWithMetadatav2Internal(uint8_t* frame,
   if (frameID != IDENTIFY_NO_FRAME && !showStatusMessages) {
     if ((monochromeMode || monochromePaletteMode) &&
         IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
+          g_serumData.triggerIDs[lastfound][0] = 0xffffffff;
           bypassMonochromeCheck = true;
     }
     if (frameID != IDENTIFY_NO_FRAME) {

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -4530,7 +4530,7 @@ static uint32_t Serum_ColorizeWithMetadatav2Internal(uint8_t* frame,
   if (frameID != IDENTIFY_NO_FRAME && !showStatusMessages) {
     if ((monochromeMode || monochromePaletteMode) &&
         IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
-          bypassMonochromeCheck = true;
+      bypassMonochromeCheck = true;
     }
     if (frameID != IDENTIFY_NO_FRAME) {
       uint32_t triggerId = g_serumData.triggerIDs[lastfound][0];

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -4529,10 +4529,10 @@ static uint32_t Serum_ColorizeWithMetadatav2Internal(uint8_t* frame,
   if (frameID != IDENTIFY_NO_FRAME && !showStatusMessages) {
     if ((monochromeMode || monochromePaletteMode) &&
         IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
-		if(lastFrameId == IDENTIFY_NO_FRAME) {
-			frameID = IDENTIFY_NO_FRAME;
-		}
-	}
+      if (lastfound != IDENTIFY_NO_FRAME) {
+        frameID = IDENTIFY_NO_FRAME;
+      }
+    }
     if (frameID != IDENTIFY_NO_FRAME) {
       uint32_t triggerId = g_serumData.triggerIDs[lastfound][0];
       monochromeMode = (triggerId == MONOCHROME_TRIGGER_ID);

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -4530,7 +4530,6 @@ static uint32_t Serum_ColorizeWithMetadatav2Internal(uint8_t* frame,
   if (frameID != IDENTIFY_NO_FRAME && !showStatusMessages) {
     if ((monochromeMode || monochromePaletteMode) &&
         IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
-          g_serumData.triggerIDs[lastfound][0] = 0xffffffff;
           bypassMonochromeCheck = true;
     }
     if (frameID != IDENTIFY_NO_FRAME) {

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -4527,12 +4527,12 @@ static uint32_t Serum_ColorizeWithMetadatav2Internal(uint8_t* frame,
     if (showStatusMessages) ignoreUnknownFramesTimeout = 0x2000;
   }
   if (frameID != IDENTIFY_NO_FRAME && !showStatusMessages) {
-    if ((monochromeMode || monochromePaletteMode) &&
-        IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
-      if (lastfound != IDENTIFY_NO_FRAME) {
-        frameID = IDENTIFY_NO_FRAME;
-      }
-    }
+    //if ((monochromeMode || monochromePaletteMode) &&
+    //    IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
+    //  if (lastfound != IDENTIFY_NO_FRAME) {
+    //    frameID = IDENTIFY_NO_FRAME;
+    //  }
+    //}
     if (frameID != IDENTIFY_NO_FRAME) {
       uint32_t triggerId = g_serumData.triggerIDs[lastfound][0];
       monochromeMode = (triggerId == MONOCHROME_TRIGGER_ID);

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -166,6 +166,7 @@ uint32_t lastFrameId = 0;  // last frame ID identified
 uint16_t sceneBackgroundFrame[256 * 64] = {0};
 uint16_t sceneBackgroundWidth = 0;
 uint16_t sceneBackgroundHeight = 0;
+bool bypassMonochromeCheck = false;
 bool monochromeMode = false;
 bool monochromePaletteMode = false;
 bool showStatusMessages = false;
@@ -4527,19 +4528,20 @@ static uint32_t Serum_ColorizeWithMetadatav2Internal(uint8_t* frame,
     if (showStatusMessages) ignoreUnknownFramesTimeout = 0x2000;
   }
   if (frameID != IDENTIFY_NO_FRAME && !showStatusMessages) {
-    //if ((monochromeMode || monochromePaletteMode) &&
-    //    IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
-    //  if (lastfound != IDENTIFY_NO_FRAME) {
-    //    frameID = IDENTIFY_NO_FRAME;
-    //  }
-    //}
+    if ((monochromeMode || monochromePaletteMode) &&
+        IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
+          bypassMonochromeCheck = true;
+    }
     if (frameID != IDENTIFY_NO_FRAME) {
       uint32_t triggerId = g_serumData.triggerIDs[lastfound][0];
-      monochromeMode = (triggerId == MONOCHROME_TRIGGER_ID);
-      monochromePaletteMode = false;
-      if (triggerId == MONOCHROME_PALETTE_TRIGGER_ID) {
-        monochromePaletteMode = CaptureMonochromePaletteFromFrameV2(lastfound);
-        monochromeMode = false;
+      if (!bypassMonochromeCheck) {
+        monochromeMode = (triggerId == MONOCHROME_TRIGGER_ID);
+        monochromePaletteMode = false;
+        if (triggerId == MONOCHROME_PALETTE_TRIGGER_ID) {
+          monochromePaletteMode = CaptureMonochromePaletteFromFrameV2(lastfound);
+          monochromeMode = false;
+        }
+        bypassMonochromeCheck = false;
       }
       if (g_serumData.triggerIDs[lastfound][0] > 0xff98)
         g_serumData.triggerIDs[lastfound][0] = 0xffffffff;

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -4530,18 +4530,15 @@ static uint32_t Serum_ColorizeWithMetadatav2Internal(uint8_t* frame,
   if (frameID != IDENTIFY_NO_FRAME && !showStatusMessages) {
     if ((monochromeMode || monochromePaletteMode) &&
         IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
-          bypassMonochromeCheck = true;
+          g_serumData.triggerIDs[lastfound][0] = 0xffffffff;
     }
     if (frameID != IDENTIFY_NO_FRAME) {
       uint32_t triggerId = g_serumData.triggerIDs[lastfound][0];
-      if (!bypassMonochromeCheck) {
-        monochromeMode = (triggerId == MONOCHROME_TRIGGER_ID);
-        monochromePaletteMode = false;
-        if (triggerId == MONOCHROME_PALETTE_TRIGGER_ID) {
-          monochromePaletteMode = CaptureMonochromePaletteFromFrameV2(lastfound);
-          monochromeMode = false;
-        }
-        bypassMonochromeCheck = false;
+      monochromeMode = (triggerId == MONOCHROME_TRIGGER_ID);
+      monochromePaletteMode = false;
+      if (triggerId == MONOCHROME_PALETTE_TRIGGER_ID) {
+        monochromePaletteMode = CaptureMonochromePaletteFromFrameV2(lastfound);
+        monochromeMode = false;
       }
       if (g_serumData.triggerIDs[lastfound][0] > 0xff98)
         g_serumData.triggerIDs[lastfound][0] = 0xffffffff;

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -4529,7 +4529,9 @@ static uint32_t Serum_ColorizeWithMetadatav2Internal(uint8_t* frame,
   if (frameID != IDENTIFY_NO_FRAME && !showStatusMessages) {
     if ((monochromeMode || monochromePaletteMode) &&
         IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
-      frameID = IDENTIFY_NO_FRAME;
+		if(knownFrameId > g_serumData.nframes) {
+			frameID = IDENTIFY_NO_FRAME;
+		}
     }
     if (frameID != IDENTIFY_NO_FRAME) {
       uint32_t triggerId = g_serumData.triggerIDs[lastfound][0];

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -4530,15 +4530,18 @@ static uint32_t Serum_ColorizeWithMetadatav2Internal(uint8_t* frame,
   if (frameID != IDENTIFY_NO_FRAME && !showStatusMessages) {
     if ((monochromeMode || monochromePaletteMode) &&
         IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
-          g_serumData.triggerIDs[lastfound][0] = 0xffffffff;
+          bypassMonochromeCheck = true;
     }
     if (frameID != IDENTIFY_NO_FRAME) {
       uint32_t triggerId = g_serumData.triggerIDs[lastfound][0];
-      monochromeMode = (triggerId == MONOCHROME_TRIGGER_ID);
-      monochromePaletteMode = false;
-      if (triggerId == MONOCHROME_PALETTE_TRIGGER_ID) {
-        monochromePaletteMode = CaptureMonochromePaletteFromFrameV2(lastfound);
-        monochromeMode = false;
+      if (!bypassMonochromeCheck) {
+        monochromeMode = (triggerId == MONOCHROME_TRIGGER_ID);
+        monochromePaletteMode = false;
+        if (triggerId == MONOCHROME_PALETTE_TRIGGER_ID) {
+          monochromePaletteMode = CaptureMonochromePaletteFromFrameV2(lastfound);
+          monochromeMode = false;
+        }
+        bypassMonochromeCheck = false;
       }
       if (g_serumData.triggerIDs[lastfound][0] > 0xff98)
         g_serumData.triggerIDs[lastfound][0] = 0xffffffff;

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -4532,7 +4532,7 @@ static uint32_t Serum_ColorizeWithMetadatav2Internal(uint8_t* frame,
 		if(lastFrameId == IDENTIFY_NO_FRAME) {
 			frameID = IDENTIFY_NO_FRAME;
 		}
-    }
+	}
     if (frameID != IDENTIFY_NO_FRAME) {
       uint32_t triggerId = g_serumData.triggerIDs[lastfound][0];
       monochromeMode = (triggerId == MONOCHROME_TRIGGER_ID);

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -4529,7 +4529,7 @@ static uint32_t Serum_ColorizeWithMetadatav2Internal(uint8_t* frame,
   if (frameID != IDENTIFY_NO_FRAME && !showStatusMessages) {
     if ((monochromeMode || monochromePaletteMode) &&
         IsFullBlackFrame(frame, g_serumData.fwidth * g_serumData.fheight)) {
-		if(knownFrameId > g_serumData.nframes) {
+		if(lastFrameId == IDENTIFY_NO_FRAME) {
 			frameID = IDENTIFY_NO_FRAME;
 		}
     }


### PR DESCRIPTION
If the frame before the black frame has a monochrome trigger/the stream was in monochrome mode, continue with this monochrome mode. Even if the black frame in the project does not have the monochrome trigger, it should still continue on. 